### PR TITLE
Override respond, not to_format

### DIFF
--- a/lib/responders/decorate_responder.rb
+++ b/lib/responders/decorate_responder.rb
@@ -1,6 +1,6 @@
 module Responders
   module DecorateResponder
-    def to_format
+    def respond
       @resource = decorate_resource(resource)
       super
     end


### PR DESCRIPTION
This means decoration will be applied no matter the request format.
Necessary because the responders gem has some default methods for
e.g. `to_html`, `to_js`.