### PR TITLE
Support controller method #decoration_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,20 @@ end
 
 If you're using a decorator gem such as [draper](https://github.com/drapergem/draper) that injects a `decorate` method into your resources they will get decorated automatically.
 
-You can also explicitly decorate your resources by adding a `decorate` method to your controller:
+When using draper, you may want to pass a [context hash](https://github.com/drapergem/draper#adding-context) from the controller to the decorator.
+You can provide this context by adding a (public!) `decoration_context` method to the controller:
+
+```ruby
+class AppController
+  responders Responder::DecorateResponder
+  
+  def decoration_context
+    { color: false }
+  end
+end
+```
+
+If you want to build even more advanced decoration logic, you can also explicitly decorate your resources by adding a `decorate` method to your controller:
 
 ```ruby
 class AppController

--- a/lib/responders/decorate_responder.rb
+++ b/lib/responders/decorate_responder.rb
@@ -7,7 +7,15 @@ module Responders
 
     def decorate_resource(res)
       return controller.decorate(res) if controller.respond_to? :decorate
-      return res.decorate if res.respond_to? :decorate
+
+      if res.respond_to? :decorate
+        if controller.respond_to? :decoration_context
+          return res.decorate context: controller.decoration_context
+        else
+          return res.decorate
+        end
+      end
+
       res
     end
   end

--- a/test/decorate_with_context_responder_test.rb
+++ b/test/decorate_with_context_responder_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper.rb'
+
+class DecorateWithContextResponderTest < ActionController::TestCase
+  tests DecorateWithContextController
+
+  def json
+    JSON[@response.body]
+  end
+
+  def test_non_decoration
+    DecorateWithContextController.resource = ['abc']
+
+    get :index, format: :json
+
+    assert_equal 1, json.size
+    assert_equal 'abc', json[0]
+  end
+
+  def test_decoration_with_context
+    DecorateWithContextController.resource = User.new(name: 'John')
+
+    get :index, format: :json
+
+    assert_equal 'UserDecorator', json['class']
+    assert_equal 'bar', json['foo']
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ Responders::Routes = ActionDispatch::Routing::RouteSet.new
 Responders::Routes.draw do
   get '/index' => 'app#index'
   get '/ex' => 'explicit_decorate#index'
+  get '/ctx' => 'decorate_with_context#index'
 end
 
 class ActiveSupport::TestCase
@@ -30,8 +31,8 @@ class User
     @name = name
   end
 
-  def decorate
-    UserDecorator.new self
+  def decorate(*args)
+    UserDecorator.new self, *args
   end
 end
 
@@ -39,7 +40,7 @@ class UserDecorator < Draper::Decorator
   decorates User
 
   def as_json(_options)
-    { class: 'UserDecorator' }
+    { class: 'UserDecorator' }.merge(context)
   end
 end
 
@@ -76,5 +77,22 @@ class ExplicitDecorateController < ActionController::Base
 
   def decorate(resource)
     MyDecorator.new(resource)
+  end
+end
+
+class DecorateWithContextController < ActionController::Base
+  include Responders::Routes.url_helpers
+
+  cattr_accessor :resource
+
+  self.responder = AppResponder
+  respond_to :json
+
+  def index
+    respond_with self.class.resource
+  end
+
+  def decoration_context
+    {foo: 'bar'}
   end
 end


### PR DESCRIPTION
This can be a nifty shortcut for a typical scenario when using this
responder with Draper, and would mean we would have to provide our own
#decorate method less often.

@jgraichen @mswart